### PR TITLE
Fix unmatched case bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,16 @@ if(unit_tests)
     if(NOT Boost_FOUND)
         set(unit_tests OFF)
     else()
-        add_definition("-DUNIT_TESTS")
+        add_definitions("-DUNIT_TESTS")
         include_directories(${Boost_INCLUDE_DIRS})
     endif() 
 
     enable_testing()
 
     target_link_libraries(obfy_test
-    		    ${Boost_FILESYSTEM_LIBRARY}
-    		    ${Boost_SYSTEM_LIBRARY}
-                    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY}
+        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
     )
 
     add_test(NAME obfy_test COMMAND obfy_test)

--- a/instr.h
+++ b/instr.h
@@ -525,7 +525,7 @@ public:
         while(it != steps.end())
         {
             bool increased = false;
-            // see if  this is a branch or body
+            // see if this is a branch
             if(dynamic_cast<const branch<CT>*>(*it) || dynamic_cast<const branch<const CT>*>(*it))
             {
                 // branch. Execute it, see if it returns true or false
@@ -557,6 +557,10 @@ public:
                         ++it;
                     }
                 }
+            }
+            else if(dynamic_cast<const body*>(*it))
+            {
+                // skip body
             }
             else
             {

--- a/main.cpp
+++ b/main.cpp
@@ -256,6 +256,14 @@ int case_tester()
 
         CASE ( something )
 
+            WHEN("Y") DO
+                BREAK;
+            DONE
+
+            WHEN("X") DO
+                BREAK;
+            DONE
+
             WHEN("A") OR WHEN("B") DO
                 V(n) = N(42);
                 BREAK;


### PR DESCRIPTION
when a matching `WHEN` has not been found yet for `CASE() ... ENDCASE` and we encounter a `body`, an exception is thrown:

```
Running 6 test cases...
unknown location:0: fatal error: in "case_test": std::string: invalid type:PKN3obf16case_instructionE
./obfy/main.cpp:377: last checkpoint
```
only `branch` is checked dynamically before exception is thrown,  and so `body` falls into the `throw` for unknown type.
    
Fix is to add a dynamic check for `body` and ignore it.

This PR modifies the CASE testcase so that it fails with the issue, and fixes the issue.

```
Running 6 test cases...

*** No errors detected
```