### PR TITLE
Added missing copy constructor to remove compile warnings.

### DIFF
--- a/instr.h
+++ b/instr.h
@@ -106,6 +106,7 @@ public:
     /* Construction, destruction */
     refholder() = delete;
     refholder(T& pv) : v(pv) {}
+    refholder(const refholder& ov) : v(ov.v) {}
     refholder(T&&) = delete;
 
     ~refholder() = default;


### PR DESCRIPTION
It gives compiler errors when using gcc version 9.1.1 (-Werror=deprecated-copy).